### PR TITLE
fix: react plugin rules

### DIFF
--- a/.changeset/perfect-tables-swim.md
+++ b/.changeset/perfect-tables-swim.md
@@ -1,0 +1,5 @@
+---
+"@virtual-live-lab/eslint-config": patch
+---
+
+disable react/prop-types, enable react/jsx-no-target-blank

--- a/packages/eslint-config/src/base/react.ts
+++ b/packages/eslint-config/src/base/react.ts
@@ -19,6 +19,8 @@ const reactConfig = [
       rules: {
         "react/jsx-boolean-value": "warn",
         "react/jsx-curly-brace-presence": "error",
+        "react/prop-types": "off",
+        "react/jsx-no-target-blank": "warn",
       },
       settings: {
         react: {


### PR DESCRIPTION
- `react/prop-types` を無効化した
  - React.FC<T> や forwardRef<T> を正常に認識できておらず不必要にエラーが出る
  - `eslint-config-next` でも off にされているので問題ないのでは
    - cf: https://github.com/vercel/next.js/blob/canary/packages/eslint-config-next/index.js
- `react/jsx-no-target-blank` を有効化した
  - `eslint-config-next` では無効にされているが一般的に考えると良いルール