### PR TITLE
ts: noUncheckedSideEffectImportを有効化する

### DIFF
--- a/.changeset/orange-geckos-poke.md
+++ b/.changeset/orange-geckos-poke.md
@@ -1,0 +1,5 @@
+---
+"@virtual-live-lab/tsconfig": patch
+---
+
+Enable noUncheckedSideEffectImports

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -14,6 +14,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "resolveJsonModule": true,
+    "noUncheckedSideEffectImports": true,
     // interop
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/tsconfig/docs/base/compiler-options.md
+++ b/packages/tsconfig/docs/base/compiler-options.md
@@ -268,6 +268,14 @@ Module Suffixに指定したSuffixを考慮してモジュール解決を行う�
 
 **触らぬ神に祟りなし。**
 
+### [noUncheckedSideEffectImports](https://www.typescriptlang.org/ja/tsconfig/#noUncheckedSideEffectImports)
+
+設定値: `true`
+
+`.css`のimportなど、値をimportしないimport文について、ファイルまたはモジュール型定義が存在しない場合にエラーを出すかどうかを設定する。
+
+安全性が向上するため、有効にしておく。
+
 ### [Paths](https://www.typescriptlang.org/ja/tsconfig/#paths)
 
 設定値: not set


### PR DESCRIPTION
## Outline

TypeScript 5.6で使えるようになった `noUncheckedSideEffectImports` を有効化する。
特に `.css` のimportなどを検証するのに有利であり、一般的なバンドラはこれらのモジュール型定義を
提供しているので有効にしておくことでより安全に開発できる。

## やったこと
`noUncheckedSideEffectImports` の有効化
docsに追記