### PR TITLE
typesciript-eslintの有効化ルールを増やす

### DIFF
--- a/packages/eslint-config/src/base/typescript.ts
+++ b/packages/eslint-config/src/base/typescript.ts
@@ -24,8 +24,6 @@ const tsConfig = tseslint.config({
     "@stylistic/ts": stylisticTs,
   },
   rules: {
-    // SEE: https://zenn.dev/cybozu_frontend/articles/ts-eslint-v6-guide
-    // v6 で recommended から削除されたものを有効化
     "@stylistic/ts/no-extra-semi": "error",
     "@typescript-eslint/adjacent-overload-signatures": "off",
     // #175
@@ -39,11 +37,12 @@ const tsConfig = tseslint.config({
     "@typescript-eslint/class-literal-property-style": "off",
     "@typescript-eslint/consistent-generic-constructors": "off",
     "@typescript-eslint/consistent-indexed-object-style": "off",
-    "@typescript-eslint/consistent-type-assertions": "off",
+    "@typescript-eslint/consistent-type-assertions": "error",
     "@typescript-eslint/consistent-type-definitions": "off",
-    "@typescript-eslint/consistent-type-imports": ["error"],
+    "@typescript-eslint/consistent-type-exports": "error",
+    "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/no-confusing-non-null-assertion": "off",
-    // v6 で recommended に追加されたルールを無効化
+    "@typescript-eslint/no-deprecated": "warn",
     "@typescript-eslint/no-duplicate-enum-values": "off",
     "@typescript-eslint/no-import-type-side-effects": "error",
     // this is for react-hook-form
@@ -55,11 +54,11 @@ const tsConfig = tseslint.config({
         },
       },
     ],
-    // v6 で strict に移動したルールを有効化
     "@typescript-eslint/no-non-null-assertion": "warn",
     "@typescript-eslint/no-unsafe-declaration-merging": "off",
     "@typescript-eslint/prefer-for-of": "off",
     "@typescript-eslint/prefer-function-type": "off",
+    "@typescript-eslint/promise-function-async": "error",
     // #97
     "@typescript-eslint/strict-boolean-expressions": [
       "error",

--- a/packages/eslint-config/test/__snapshots__/snapshot.test.ts.snap
+++ b/packages/eslint-config/test/__snapshots__/snapshot.test.ts.snap
@@ -2370,10 +2370,13 @@ exports[`Test ESLint config with snapshot > react preset > matches snapshot 1`] 
       0,
     ],
     "@typescript-eslint/consistent-type-assertions": [
-      0,
+      2,
     ],
     "@typescript-eslint/consistent-type-definitions": [
       0,
+    ],
+    "@typescript-eslint/consistent-type-exports": [
+      2,
     ],
     "@typescript-eslint/consistent-type-imports": [
       2,
@@ -2410,6 +2413,9 @@ exports[`Test ESLint config with snapshot > react preset > matches snapshot 1`] 
     ],
     "@typescript-eslint/no-confusing-non-null-assertion": [
       0,
+    ],
+    "@typescript-eslint/no-deprecated": [
+      1,
     ],
     "@typescript-eslint/no-duplicate-enum-values": [
       0,
@@ -2561,6 +2567,9 @@ exports[`Test ESLint config with snapshot > react preset > matches snapshot 1`] 
       2,
     ],
     "@typescript-eslint/prefer-string-starts-ends-with": [
+      2,
+    ],
+    "@typescript-eslint/promise-function-async": [
       2,
     ],
     "@typescript-eslint/quotes": [
@@ -3723,10 +3732,13 @@ exports[`Test ESLint config with snapshot > ts preset > matches snapshot 1`] = `
       0,
     ],
     "@typescript-eslint/consistent-type-assertions": [
-      0,
+      2,
     ],
     "@typescript-eslint/consistent-type-definitions": [
       0,
+    ],
+    "@typescript-eslint/consistent-type-exports": [
+      2,
     ],
     "@typescript-eslint/consistent-type-imports": [
       2,
@@ -3763,6 +3775,9 @@ exports[`Test ESLint config with snapshot > ts preset > matches snapshot 1`] = `
     ],
     "@typescript-eslint/no-confusing-non-null-assertion": [
       0,
+    ],
+    "@typescript-eslint/no-deprecated": [
+      1,
     ],
     "@typescript-eslint/no-duplicate-enum-values": [
       0,
@@ -3914,6 +3929,9 @@ exports[`Test ESLint config with snapshot > ts preset > matches snapshot 1`] = `
       2,
     ],
     "@typescript-eslint/prefer-string-starts-ends-with": [
+      2,
+    ],
+    "@typescript-eslint/promise-function-async": [
       2,
     ],
     "@typescript-eslint/quotes": [


### PR DESCRIPTION
- `@typescript-eslint/consistent-type-assertions`
- `@typescript-eslint/consistent-type-exports`
- `@typescript-eslint/no-deprecated`
- `@typescript-eslint/promise-function-async`