### PR TITLE
fix: mark eslint-plugin-react-refresh as dependency

### DIFF
--- a/.changeset/cool-plums-switch.md
+++ b/.changeset/cool-plums-switch.md
@@ -1,0 +1,5 @@
+---
+"@virtual-live-lab/eslint-config": patch
+---
+
+fix: mark eslint-plugin-react-refresh as dependency

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-perfectionist": "^3.9.1",
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-refresh": "^0.4.14",
     "eslint-plugin-tailwindcss": "^3.17.5",
     "globals": "^15.11.0",
     "pkg-dir": "^8.0.0",
@@ -63,7 +64,6 @@
     "@types/node": "20.17.1",
     "@virtual-live-lab/tsconfig": "workspace:^",
     "@vitest/coverage-istanbul": "2.1.3",
-    "eslint-plugin-react-refresh": "^0.4.14",
     "tsup": "8.3.5",
     "vitest": "2.1.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^5.0.0
         version: 5.0.0(eslint@9.13.0(jiti@1.21.0))
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.14
+        version: 0.4.14(eslint@9.13.0(jiti@1.21.0))
       eslint-plugin-tailwindcss:
         specifier: ^3.17.5
         version: 3.17.5(tailwindcss@3.4.3)
@@ -135,9 +138,6 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
         version: 2.1.3(vitest@2.1.3(@types/node@20.17.1))
-      eslint-plugin-react-refresh:
-        specifier: ^0.4.14
-        version: 0.4.14(eslint@9.13.0(jiti@1.21.0))
       tsup:
         specifier: 8.3.5
         version: 8.3.5(jiti@1.21.0)(postcss@8.4.47)(typescript@5.6.3)


### PR DESCRIPTION
## Outline
`eslint-plugin-react-refresh` が `devDependencies` としてマークされてしまい、
使用時に自動でインストールされなくなっているので修正する