### PR TITLE
ci: スナップショット更新のブランチ名を再試行も含めて一意にする

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -152,7 +152,7 @@ jobs:
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
           if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
-            git switch -c "bot/update-snapshot-$(TZ=UTC-9 date +'%Y%m')-${SHA:0:7}"
+            git switch -c "bot/update-snapshot-$(TZ=UTC-9 date +'%Y%m')-${{ github.run_id }}-${{ github.run_attempt }}"
           fi
 
       - name: Setup Node.js and pnpm


### PR DESCRIPTION
## Outline
スナップショットを手動更新する際に生成されるブランチ名が一意でなく衝突するものになっていたので修正する。

## 変更点
- `github.run_id` を含めることで、実行ごとにブランチ名が変わる
- `github.run_attempt` を含めることで、同一実行内において `rerun workflow` を行った際もブランチ名が変わる