### PR TITLE
fix: heads と tags を取り違えていてPRが作成されなくなってしまった

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -226,4 +226,4 @@ jobs:
           gh pr create --base ${{ github.ref }} --body-file CHANGES.md --title "update snapshot (github-actions)"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          WARN_BECAUSE_REF_IS_TAG: ${{ contains(github.ref, 'refs/heads') }}
+          WARN_BECAUSE_REF_IS_TAG: ${{ contains(github.ref, 'refs/tags') }}


### PR DESCRIPTION
#322 で workflow_dispatch 時に tag を指定すると PR を作成せず警告を出すようにしていたが、
疲れからか不幸にも branch を指定した際に警告を出すようにしてしまう...