### PR TITLE
新しすぎるcompilerOptionsを落とす

### DIFF
--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -14,7 +14,6 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "resolveJsonModule": true,
-    "noUncheckedSideEffectImports": true,
     // interop
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Outline
[peerDependenciesの指定を緩める](https://www.notion.so/virtual-live-lab/peerDependencies-1561dd356de580aba2e9fa455d320ed1?pvs=4) にあたり、`noUncheckedSideEffectImports` がデフォルトで有効になっていることで
peerDependencies も TS5.6 以上を要求せざるを得ない状態になっている。
TS 5.6 がリリースされて間もなく、まだそこまで TypeScript をアップデートできている環境は少ないことを考慮すると、
この設定をデフォルトで有効化しないことで peerDependencies を TS5.0以上 まで下げたほうがより汎用性が上がると判断した。

## やったこと
`noUncheckedSideEffectImports` を base.json から落とした
