### PR TITLE
hono プリセットが暗黙的に cloudflare workers ランタイムを前提としていたのをやめる

### DIFF
--- a/packages/tsconfig/hono.json
+++ b/packages/tsconfig/hono.json
@@ -1,8 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Hono",
-  "extends": "./cloudflare-workers.json",
+  "extends": "./base.json",
   "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext"],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx"
   }


### PR DESCRIPTION
## Outline
これまで hono preset は暗黙的に Cloudflare Workers 環境での動作を前提とした型定義の要求をしていたが、
それを辞めてランタイムに依存した型が入らないようにする