### PR TITLE
fix: remove cloudflare workers type from optional peer deps

### DIFF
--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -6,13 +6,7 @@
     "*.json"
   ],
   "peerDependencies": {
-    "@cloudflare/workers-types": "^4.20241205.0",
     "typescript": "^5.7.2"
-  },
-  "peerDependenciesMeta": {
-    "@cloudflare/workers-types": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20241205.0",


### PR DESCRIPTION
## Outline
[peerDependenciesを緩める](https://www.notion.so/virtual-live-lab/peerDependencies-1561dd356de580aba2e9fa455d320ed1?pvs=4) にあたって、自動更新が行われなくなることから
変に古い cloudflare workers の型定義を optional peer dependencies として要求する可能性がある


## やったこと
cloudflare workers の型定義を peerDependencies から外して完全にユーザー側に任せる