### PR TITLE
fix: renovate ignore peerDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,6 +65,12 @@
       "matchDatasources": ["npm"]
     },
     {
+      "groupName": "peerDependencies",
+      "matchDepTypes": ["peerDependencies"],
+      "matchDatasources": ["npm"],
+      "enabled": false
+    },
+    {
       "groupName": "root dependencies",
       "matchFileNames": ["package.json"]
     },


### PR DESCRIPTION
# 概要
`peerDependencies` の緩さを守るための定跡として、renovate の自動更新を止める。

# やったこと
`renovate.json` にDepType によるルールを追加し、一般に peerDependencies 内の更新を禁止にした。