### PR TITLE
fix: [VLL-DEV-34] peerDependenciesの指定を緩める

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -30,7 +30,7 @@
     "node": ">= 20.11.0 || >= 21.2.0 || >= 22.0.0"
   },
   "peerDependencies": {
-    "eslint": "^9.16.0"
+    "eslint": "^8.57.0 || ^9.0.0"
   },
   "dependencies": {
     "@astrojs/compiler": "2.10.3",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -22,8 +22,8 @@
     "build": "tsup-node"
   },
   "peerDependencies": {
-    "prettier": "^3.4.2",
-    "prettier-plugin-astro": "^0.14.1"
+    "prettier": "^3.0.0",
+    "prettier-plugin-astro": "^0.11.0"
   },
   "peerDependenciesMeta": {
     "prettier-plugin-astro": {

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -23,7 +23,7 @@
   },
   "peerDependencies": {
     "prettier": "^3.0.0",
-    "prettier-plugin-astro": "^0.11.0"
+    "prettier-plugin-astro": ">=0.11.0 <0.15.0"
   },
   "peerDependenciesMeta": {
     "prettier-plugin-astro": {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -26,8 +26,8 @@
     "build": "tsup-node"
   },
   "peerDependencies": {
-    "postcss-html": "^1.7.0",
-    "stylelint": "^16.11.0"
+    "postcss-html": "^1.0.0",
+    "stylelint": "^16.0.0"
   },
   "dependencies": {
     "@double-great/stylelint-a11y": "3.0.2",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -6,7 +6,7 @@
     "*.json"
   ],
   "peerDependencies": {
-    "typescript": "^5.7.2"
+    "typescript": "^5.0.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20241205.0",


### PR DESCRIPTION
# 概要

> 現状、 各パッケージの peerDependencies が renovate の自動更新のスコープに入っているので、ルールセットを使うユーザーが常に最新の TypeScript などを要求されてしまっている。
> 
> 可能な限り peerDependencies を下げることで、より多くのライブラリ構成で使えるようにする。
> https://www.notion.so/virtual-live-lab/peerDependencies-1561dd356de580aba2e9fa455d320ed1?pvs=4

# 指定バージョン

元：[各 package ごとの peerDependencies の下限](https://www.notion.so/virtual-live-lab/peerDependencies-1561dd356de580aba2e9fa455d320ed1?pvs=4#15c1dd356de580fa9460e612a06ff724)

本当に `>=` （以上）だとまずそうなので~~すべて~~ほとんど `^` にしました

- eslint-config
  - eslint `^8.57.0 || ^9.0.0`
- prettier-config
  - pritter `^3.0.0`
  - prettier-plugin-astro ~~`^0.11.0`~~ `>=0.11.0 <0.15.0`
    - ~~これでキツ過ぎないかは未知数~~
    - ベータゆえ minor バージョンアップでも破壊的な変更をするので
- stylelint-config
  - postcss-html `^1.0.0`
  - stylelint `^16.0.0`
- tsconfig
  - typescript `^5.0.0`