### PR TITLE
PR からスナップショットを更新する際にラベルを用いる

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -18,57 +18,45 @@ on:
         required: true
         default: false
         type: boolean
-  issue_comment:
-    types: [created]
+  pull_request:
+    types: [labeled]
+    branches:
+      - "main"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  filter-packages:
-    name: Check Changed Packages (Update Snapshot)
+  check-target-packages:
+    name: Check Target Packages (Update Snapshot)
     runs-on: ubuntu-24.04
-    if: github.event_name == 'issue_comment' && github.event.issue.pull_request && !contains(github.event.comment.user.name, 'bot') && contains(github.event.comment.body, '/update-snapshot')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.user.name, 'bot')  && github.event.label.name == 'update-snapshot')
     outputs:
-      head_ref: ${{ fromJson(steps.pr-request.outputs.data).head.ref  }}
-      eslint: ${{ false || steps.filter.outputs.eslint }}
-      prettier: ${{ false || steps.filter.outputs.prettier }}
-      stylelint: ${{ false || steps.filter.outputs.stylelint }}
-    permissions:
-      contents: read
+      eslint: ${{ steps.target-packages.outputs.eslint }}
+      prettier: ${{ steps.target-packages.outputs.prettier }}
+      stylelint: ${{ steps.target-packages.outputs.stylelint }}
 
     steps:
-      - name: Get PR information
-        id: pr-request
-        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
-        with:
-          route: ${{ github.event.issue.pull_request.url }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Exit if invalid PR
+      # PR の
+      - name: Exit if triggered from invalid PR
+        if: github.event_name == 'pull_request'
         run: |
-          if [ "${{ fromJson(steps.pr-request.outputs.data).base.ref }}" != 'main' ]; then
-            echo "::error::PR base branch is not main."
-            exit 1
-          fi
-
-          if [ "${{ fromJson(steps.pr-request.outputs.data).state }}" != 'open' ]; then
+          if [ "${{ github.event.pull_request.state }}" != 'open' ]; then
             echo "::error::PR is not open."
             exit 1
           fi
 
-          if [ "${{ fromJson(steps.pr-request.outputs.data).draft }}" == 'true' ]; then
+          if [ "${{ github.event.pull_request.draft }}" == 'true' ]; then
             echo "::error::Cannot update snapshot for draft PR."
             exit 1
           fi
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ fromJson(steps.pr-request.outputs.data).head.ref }}
-
-      - name: Check changed packages (PR Comment)
+      - name: Check target packages (PR Comment)
+        if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
+        id: pr-target
         with:
-          ref: ${{ fromJson(steps.pr-request.outputs.data).head.ref }}
           filters: |
             eslint:
               - 'packages/eslint-config/**'
@@ -77,41 +65,17 @@ jobs:
             stylelint:
               - 'packages/stylelint-config/**'
 
-  check-target-packages:
-    name: Check target packages (Update Snapshot)
-    if: always()
-    needs: filter-packages
-    runs-on: ubuntu-24.04
-    outputs:
-      eslint: ${{ steps.check.outputs.eslint }}
-      prettier: ${{ steps.check.outputs.prettier }}
-      stylelint: ${{ steps.check.outputs.stylelint }}
-      head_ref: ${{ steps.set-head-ref.outputs.head_ref }}
-
-    steps:
-      - name: Check target packages
-        id: check
+      - name: Export target packages for output
+        id: target-packages
         run: |
-          if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
+          if [ ${{ github.event_name }} == 'pull_request' ]; then
+            echo "eslint=${{ steps.pr-target.outputs.eslint }}" >> $GITHUB_OUTPUT
+            echo "prettier=${{ steps.pr-target.outputs.prettier }}" >> $GITHUB_OUTPUT
+            echo "stylelint=${{ steps.pr-target.outputs.stylelint }}" >> $GITHUB_OUTPUT
+          elif [ ${{ github.event_name }} == 'workflow_dispatch'  ]; then
             echo "eslint=${{ github.event.inputs.eslint }}" >> $GITHUB_OUTPUT
             echo "prettier=${{ github.event.inputs.prettier }}" >> $GITHUB_OUTPUT
             echo "stylelint=${{ github.event.inputs.stylelint }}" >> $GITHUB_OUTPUT
-          elif [ ${{ github.event_name }} == 'issue_comment'  ]; then
-            echo "eslint=${{ needs.filter-packages.outputs.eslint }}" >> $GITHUB_OUTPUT
-            echo "prettier=${{ needs.filter-packages.outputs.prettier }}" >> $GITHUB_OUTPUT
-            echo "stylelint=${{ needs.filter-packages.outputs.stylelint }}" >> $GITHUB_OUTPUT
-          else
-            echo "::error::Workflow called by unexpected event."
-            exit 1
-          fi
-
-      - name: Set head ref
-        id: set-head-ref
-        run: |
-          if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
-            echo "head_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
-          elif [ ${{ github.event_name }} == 'issue_comment'  ]; then
-            echo "head_ref=${{ needs.filter-packages.outputs.head_ref }}" >> $GITHUB_OUTPUT
           else
             echo "::error::Workflow called by unexpected event."
             exit 1
@@ -120,7 +84,7 @@ jobs:
   update-snapshot:
     name: Update Snapshot (Update Snapshot)
     needs: check-target-packages
-    if: always() && (needs.check-target-packages.outputs.eslint == 'true' || needs.check-target-packages.outputs.prettier == 'true' || needs.check-target-packages.outputs.stylelint == 'true')
+    if: (needs.check-target-packages.outputs.eslint == 'true' || needs.check-target-packages.outputs.prettier == 'true' || needs.check-target-packages.outputs.stylelint == 'true')
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -128,7 +92,8 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+      - name: Get GitHub Access Token from GitHub App
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
         id: app-token
         with:
           app-id: ${{ vars.ACTIONS_MIKU_APP_ID }}
@@ -140,17 +105,28 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - name: Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ needs.check-target-packages.outputs.head_ref }}
-          token: ${{ steps.app-token.outputs.token }}
-
       - name: Configure Git Identity
         run: |
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
+      - name: Checkout Repo (Pull Request)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Checkout Repo (Workflow Dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.ref }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create Branch (Workflow Dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
           if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
             git switch -c "bot/update-snapshot-$(TZ=UTC-9 date +'%Y%m')-${{ github.run_id }}-${{ github.run_attempt }}"
           fi
@@ -192,8 +168,8 @@ jobs:
               echo "- Stylelint" >> CHANGES.md
           fi
 
-      - name: Comment to PR (Issue Comment)
-        if: github.event_name == 'issue_comment'
+      - name: Comment to PR (Pull Request)
+        if: github.event_name == 'pull_request'
         run: |
           set -eu
           if [ ! -f CHANGES.md ]; then
@@ -201,16 +177,14 @@ jobs:
             exit 0
           fi
 
-          gh pr comment ${{ github.event.issue.number }} --body-file CHANGES.md --edit-last \
-            || gh pr comment ${{ github.event.issue.number}} --body-file CHANGES.md
+          gh pr comment ${{ github.event.pull_request.number }} --body-file CHANGES.md --edit-last \
+            || gh pr comment ${{ github.event.pull_request.number}} --body-file CHANGES.md
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Create Pull Request (Workflow Dispatch)
         if: github.event_name == 'workflow_dispatch'
         # tag 上で実行した場合は warning を出して PR は作成しない
-        # 本当は filter-packages より前段階にチェック用の job を作ったほうが
-        # workflow_dispatch と issue_comment の差分吸収もできて良い
         run: |
           set -eu
           if [ $WARN_BECAUSE_REF_IS_TAG == 'true' ]; then


### PR DESCRIPTION
## Outline
現状、 PR からスナップショットを更新する場合に特定のコメントをトリガーにしているため、
`github.event.pull_request` が使えないことで workflow が複雑化している。
これを、`update-snapshot` ラベルを付けたら実行にすることで、 `github.event.pull_request` を使えるようにして簡略化する

なお、副次的効果として PR の status check からスナップショット更新 workflow の実行状況が見られるようになる
