### PR TITLE
GitHub Actions の小さな改善お徳用セット

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -12,6 +12,10 @@ on:
       - "package.json"
       - ".github/workflows/pkg-pr-new.yml"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   paths-filter:
     name: Filter Changed Packages (Publish Preview Package)

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -12,6 +12,10 @@ on:
       - "package.json"
       - ".github/workflows/pkg-pr-new.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   label:
     name: Auto PR Label

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   release:
     name: Test and Release (Release)

--- a/.github/workflows/renovate-changeset.yml
+++ b/.github/workflows/renovate-changeset.yml
@@ -13,6 +13,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   renovate:
     name: Update Renovate PR

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   paths-filter:
     name: Filter Changed Packages (Test Package)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,26 +69,29 @@ jobs:
       - name: Test ESLint Config
         id: eslint
         if: ${{ needs.paths-filter.outputs.eslint == 'true' }}
-        continue-on-error: true
         run: pnpm run build:eslint && pnpm run test --project eslint-config
 
       - name: Test Prettier Config
         id: prettier
         if: ${{ needs.paths-filter.outputs.prettier == 'true' }}
-        continue-on-error: true
         run: pnpm run build:prettier && pnpm run test --project prettier-config
 
       - name: Test Stylelint Config
         id: stylelint
         if: ${{ needs.paths-filter.outputs.stylelint == 'true' }}
-        continue-on-error: true
         run: pnpm run build:stylelint && pnpm run test --project stylelint-config
 
-      - name: Comment if any Error
-        if: steps.eslint.outcome == 'failure' || steps.prettier.outcome == 'failure' || steps.stylelint.outcome == 'failure'
+      - name: Comment if success
         run: |
-          set -eu
+          # Create a comment body
+          cat << EOF > COMMENT.md
+          ## ✅ Snapshot test success
+          See the details: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          EOF
 
+      - name: Comment if any Error
+        if: ${{ always() && (steps.eslint.outcome == 'failure' || steps.prettier.outcome == 'failure' || steps.stylelint.outcome == 'failure') }}
+        run: |
           # Create a comment body
           cat << EOF > COMMENT.md
           ## 🚨 Snapshot test failed
@@ -114,25 +117,14 @@ jobs:
           ### ⏭️ Next Steps
           If snapshot changes are...
 
-          **expected**: update the snapshots by \`/update-snapshot\`
+          **expected**: update the snapshots by adding \`update-snapshot\` label
 
           **unexpected**: check diff and fix rules
           EOF
 
-      - name: Comment if success
-        if: steps.eslint.outcome != 'failure' && steps.prettier.outcome != 'failure' && steps.stylelint.outcome != 'failure'
-        run: |
-          set -eu
-
-          # Create a comment body
-          cat << EOF > COMMENT.md
-          ## ✅ Snapshot test success
-          See the details: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          EOF
-
       - name: Comment to PR
+        if: always()
         run: |
-          # Edit the last comment if it exists
           if [ ! -f COMMENT.md ]; then
             echo "::warning::comment body not found."
             exit 0
@@ -142,9 +134,3 @@ jobs:
             || gh pr comment ${{ github.event.number }} --body-file COMMENT.md
         env:
           GH_TOKEN: ${{ github.token }}
-
-      - name: Mark as failure if any Error
-        if: steps.eslint.outcome == 'failure' || steps.prettier.outcome == 'failure' || steps.stylelint.outcome == 'failure'
-        run: |
-          echo "::error::Snapshot test failed."
-          exit 1

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -132,7 +132,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
-            git switch -c "bot/update-snapshot-$(TZ=UTC-9 date +'%Y%m')-${{ github.run_id }}-${{ github.run_attempt }}"
+            git switch -c "bot/update-snapshot-$(TZ=UTC-9 date +'%Y%m%d')-${{ github.run_id }}-${{ github.run_attempt }}"
           fi
 
       - name: Setup Node.js and pnpm

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -22,6 +22,10 @@ on:
     types: [labeled]
     branches:
       - "main"
+    paths:
+      - "packages/**"
+      - "package.json"
+      - ".github/workflows/update-snapshot.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -42,7 +42,6 @@ jobs:
       stylelint: ${{ steps.target-packages.outputs.stylelint }}
 
     steps:
-      # PR の
       - name: Exit if triggered from invalid PR
         if: github.event_name == 'pull_request'
         run: |
@@ -152,14 +151,12 @@ jobs:
 
       - name: Commit and Push Changes
         run: |
-          set -eu
           git add .
           git commit -m "chore: update snapshot (github-actions)"
           git push origin HEAD
 
       - name: Create change summary markdown
         run: |
-          set -eu
           echo "## 🚚 Updated snapshots" >> CHANGES.md
 
           if [ ${{ needs.check-target-packages.outputs.eslint }} == 'true' ]; then
@@ -175,7 +172,6 @@ jobs:
       - name: Comment to PR (Pull Request)
         if: github.event_name == 'pull_request'
         run: |
-          set -eu
           if [ ! -f CHANGES.md ]; then
             echo "::warning::comment body not found."
             exit 0
@@ -189,8 +185,9 @@ jobs:
       - name: Create Pull Request (Workflow Dispatch)
         if: github.event_name == 'workflow_dispatch'
         # tag 上で実行した場合は warning を出して PR は作成しない
+        # env で定義される WARN_BECAUSE_REF_IS_TAG を参照するので set -u して未定義の場合はエラーにする
         run: |
-          set -eu
+          set -u
           if [ $WARN_BECAUSE_REF_IS_TAG == 'true' ]; then
             echo "::warning::Cannot create PR to tag."
             exit 0

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -27,6 +27,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   check-target-packages:
     name: Check Target Packages (Update Snapshot)


### PR DESCRIPTION
## Outline
- `defaults.run.shell` を bash に設定
  - ref: https://gihyo.jp/article/2024/10/good-practices-for-github-actions#ghco9T3BrD
  - 合わせて `set -e` はいらなくなるので消した
- workflow_dispatch でスナップショットを更新する際のブランチに実行日を含める
- concurrency の設定漏れがあったので設定した
- Snapshot test を必ず全パッケージで走らせるために `continue-on-error` を使っていたが、失敗した step が成功として表示されて体験が微妙だったので、 失敗時の集計と最後のコメントを `always()` で走らせることで代替した