### PR TITLE
Workflow Dispatchからスナップショットを更新する際の early return

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -142,9 +142,7 @@ jobs:
       - name: Create Branch (Workflow Dispatch)
         if: github.event_name == 'workflow_dispatch'
         run: |
-          if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
-            git switch -c "bot/update-snapshot-$(TZ=UTC-9 date +'%Y%m%d')-${{ github.run_id }}-${{ github.run_attempt }}"
-          fi
+          git switch -c "bot/update-snapshot-$(TZ=UTC-9 date +'%Y%m%d')-${{ github.run_id }}-${{ github.run_attempt }}"
 
       - name: Setup Node.js and pnpm
         uses: ./.github/common/setup-node-pnpm

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -46,7 +46,7 @@ jobs:
       stylelint: ${{ steps.target-packages.outputs.stylelint }}
 
     steps:
-      - name: Exit if triggered from invalid PR
+      - name: Fail if triggered from invalid PR (Pull Request)
         if: github.event_name == 'pull_request'
         run: |
           if [ "${{ github.event.pull_request.state }}" != 'open' ]; then
@@ -56,6 +56,14 @@ jobs:
 
           if [ "${{ github.event.pull_request.draft }}" == 'true' ]; then
             echo "::error::Cannot update snapshot for draft PR."
+            exit 1
+          fi
+
+      - name: Fail if triggered from invalid Tag (Workflow Dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ ${{ contains(github.ref, 'refs/tags') }} == 'true' ]; then
+            echo "::error::Cannot update snapshot for tag."
             exit 1
           fi
 
@@ -188,15 +196,7 @@ jobs:
 
       - name: Create Pull Request (Workflow Dispatch)
         if: github.event_name == 'workflow_dispatch'
-        # tag 上で実行した場合は warning を出して PR は作成しない
-        # env で定義される WARN_BECAUSE_REF_IS_TAG を参照するので set -u して未定義の場合はエラーにする
         run: |
-          set -u
-          if [ $WARN_BECAUSE_REF_IS_TAG == 'true' ]; then
-            echo "::warning::Cannot create PR to tag."
-            exit 0
-          fi
-
           if [ ! -f CHANGES.md ]; then
             echo "::warning::comment body not found."
             exit 0
@@ -205,4 +205,3 @@ jobs:
           gh pr create --base ${{ github.ref }} --body-file CHANGES.md --title "update snapshot (github-actions)"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          WARN_BECAUSE_REF_IS_TAG: ${{ contains(github.ref, 'refs/tags') }}


### PR DESCRIPTION
## Outline
現状 tag 上でスナップショット更新を起動した際に最後まで実行してから落としているが、最初に落としたほうが経済的