### PR TITLE
fix: astro 向け設定の override の順を調整

### DIFF
--- a/.changeset/proud-planes-teach.md
+++ b/.changeset/proud-planes-teach.md
@@ -1,0 +1,5 @@
+---
+"@virtual-live-lab/stylelint-config": patch
+---
+
+fix: astro で sass を使う場合の設定の override の順を調整

--- a/packages/stylelint-config/src/factory.ts
+++ b/packages/stylelint-config/src/factory.ts
@@ -119,48 +119,50 @@ export const createConfig = (
   }
 
   if (astro) {
+    // extends: ["stylelint-config-html/astro"] は最後に override に追加しないとパーサーの設定が壊れる
+    if (sass) {
+      configs.push({
+        overrides: [
+          {
+            extends: [
+              "stylelint-config-standard-scss",
+              "stylelint-config-sass-guidelines",
+            ],
+            files: astroFiles,
+            name: "@virtual-live-lab/stylelint-config/astro/sass",
+            rules: {
+              // see: https://github.com/VirtualLiveLab/js-config/issues/178
+              "@stylistic/block-opening-brace-space-before": null,
+              "@stylistic/color-hex-case": null,
+              "@stylistic/declaration-bang-space-after": null,
+              "@stylistic/declaration-bang-space-before": null,
+              "@stylistic/declaration-block-semicolon-newline-after": null,
+              "@stylistic/declaration-block-semicolon-space-before": null,
+              "@stylistic/declaration-block-trailing-semicolon": null,
+              "@stylistic/declaration-colon-space-after": null,
+              "@stylistic/declaration-colon-space-before": null,
+              "@stylistic/function-comma-space-after": null,
+              "@stylistic/function-parentheses-space-inside": null,
+              "@stylistic/indentation": null,
+              "@stylistic/media-feature-parentheses-space-inside": null,
+              "@stylistic/no-missing-end-of-source-newline": null,
+              "@stylistic/number-leading-zero": null,
+              "@stylistic/number-no-trailing-zeros": null,
+              "@stylistic/selector-list-comma-newline-after": null,
+              "@stylistic/string-quotes": null,
+            },
+          },
+        ],
+      });
+    }
+
+    // この push が astro 向け override の最後であることを確認すること
     configs.push({
       overrides: [
         {
           extends: ["stylelint-config-html/astro"],
           files: astroFiles,
           name: "@virtual-live-lab/stylelint-config/astro",
-        },
-      ],
-    });
-  }
-
-  if (astro && sass) {
-    configs.push({
-      overrides: [
-        {
-          extends: [
-            "stylelint-config-standard-scss",
-            "stylelint-config-sass-guidelines",
-          ],
-          files: astroFiles,
-          name: "@virtual-live-lab/stylelint-config/astro-sass",
-          rules: {
-            // see: https://github.com/VirtualLiveLab/js-config/issues/178
-            "@stylistic/block-opening-brace-space-before": null,
-            "@stylistic/color-hex-case": null,
-            "@stylistic/declaration-bang-space-after": null,
-            "@stylistic/declaration-bang-space-before": null,
-            "@stylistic/declaration-block-semicolon-newline-after": null,
-            "@stylistic/declaration-block-semicolon-space-before": null,
-            "@stylistic/declaration-block-trailing-semicolon": null,
-            "@stylistic/declaration-colon-space-after": null,
-            "@stylistic/declaration-colon-space-before": null,
-            "@stylistic/function-comma-space-after": null,
-            "@stylistic/function-parentheses-space-inside": null,
-            "@stylistic/indentation": null,
-            "@stylistic/media-feature-parentheses-space-inside": null,
-            "@stylistic/no-missing-end-of-source-newline": null,
-            "@stylistic/number-leading-zero": null,
-            "@stylistic/number-no-trailing-zeros": null,
-            "@stylistic/selector-list-comma-newline-after": null,
-            "@stylistic/string-quotes": null,
-          },
         },
       ],
     });


### PR DESCRIPTION
Astro + sass を使う環境で、 astro 向けパーサー設定 → astro 向け sass 設定の順で動かすと
パーサーの設定が消滅したので順番を調整して意図通りに動くようにする