### PR TITLE
fix: do not add trailing comma in json-like files

### DIFF
--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -4,6 +4,14 @@ const config: Config = {
   arrowParens: "always",
   endOfLine: "lf",
   jsxSingleQuote: false,
+  overrides: [
+    {
+      files: ["*.json", "*.json5", "*.jsonc"],
+      options: {
+        trailingComma: "none",
+      },
+    },
+  ],
   quoteProps: "consistent",
   semi: true,
   singleQuote: false,


### PR DESCRIPTION
- closes #401 