### PR TITLE
chore: remove pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,16 +38,6 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
-    ],
-    "overrides": {
-      "@babel/runtime": "7.27.0",
-      "@octokit/endpoint": "9.0.6",
-      "@octokit/plugin-paginate-rest": "9.2.2",
-      "@octokit/request": "8.4.1",
-      "@octokit/request-error": "5.1.1",
-      "nanoid": "3.3.11",
-      "undici": "6.21.2",
-      "vite": "6.3.3"
-    }
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,16 +19,6 @@ catalogs:
       specifier: 3.1.2
       version: 3.1.2
 
-overrides:
-  '@babel/runtime': 7.27.0
-  '@octokit/endpoint': 9.0.6
-  '@octokit/plugin-paginate-rest': 9.2.2
-  '@octokit/request': 8.4.1
-  '@octokit/request-error': 5.1.1
-  nanoid: 3.3.11
-  undici: 6.21.2
-  vite: 6.3.3
-
 importers:
 
   .:
@@ -1106,7 +1096,7 @@ packages:
     resolution: {integrity: sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 6.3.3
+      vite: ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       msw:
         optional: true


### PR DESCRIPTION
セキュリティ対応で一時的に設定していたものであるため