### PR TITLE
chore: remove stylistic plugin

### DIFF
--- a/.changeset/honest-moons-deny.md
+++ b/.changeset/honest-moons-deny.md
@@ -1,0 +1,5 @@
+---
+"@virtual-live-lab/eslint-config": patch
+---
+
+refactor: switch to stylistic/eslint-plugin

--- a/.changeset/honest-moons-deny.md
+++ b/.changeset/honest-moons-deny.md
@@ -2,4 +2,4 @@
 "@virtual-live-lab/eslint-config": patch
 ---
 
-refactor: switch to stylistic/eslint-plugin
+chore: remove stylistic plugin

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -39,7 +39,7 @@
     "@eslint/config-helpers": "0.3.0",
     "@eslint/eslintrc": "3.3.1",
     "@eslint/js": "9.29.0",
-    "@stylistic/eslint-plugin-ts": "4.4.1",
+    "@stylistic/eslint-plugin": "5.2.0",
     "@typescript-eslint/utils": "8.35.0",
     "astro-eslint-parser": "1.2.2",
     "astrojs-compiler-sync": "1.1.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -39,7 +39,6 @@
     "@eslint/config-helpers": "0.3.0",
     "@eslint/eslintrc": "3.3.1",
     "@eslint/js": "9.29.0",
-    "@stylistic/eslint-plugin": "5.2.0",
     "@typescript-eslint/utils": "8.35.0",
     "astro-eslint-parser": "1.2.2",
     "astrojs-compiler-sync": "1.1.1",

--- a/packages/eslint-config/src/base/typescript.ts
+++ b/packages/eslint-config/src/base/typescript.ts
@@ -1,7 +1,6 @@
 import type { Linter } from "eslint";
 
 import { defineConfig } from "@eslint/config-helpers";
-import stylistic from "@stylistic/eslint-plugin";
 import { defu } from "defu";
 import tseslint from "typescript-eslint";
 import * as typescriptESLintParserForExtraFiles from "typescript-eslint-parser-for-extra-files";
@@ -31,11 +30,7 @@ export const tsConfig = (params: Partial<TSConfigParams> = {}) => {
       extraFiles: resolvedParams.extraFiles,
     }),
     name: "@virtual-live-lab/eslint-config/typescript",
-    plugins: {
-      "@stylistic": stylistic,
-    },
     rules: {
-      "@stylistic/no-extra-semi": "error",
       "@typescript-eslint/adjacent-overload-signatures": "off",
       // #175
       "@typescript-eslint/array-type": [

--- a/packages/eslint-config/src/base/typescript.ts
+++ b/packages/eslint-config/src/base/typescript.ts
@@ -1,7 +1,7 @@
 import type { Linter } from "eslint";
 
 import { defineConfig } from "@eslint/config-helpers";
-import stylisticTs from "@stylistic/eslint-plugin-ts";
+import stylistic from "@stylistic/eslint-plugin";
 import { defu } from "defu";
 import tseslint from "typescript-eslint";
 import * as typescriptESLintParserForExtraFiles from "typescript-eslint-parser-for-extra-files";
@@ -32,10 +32,10 @@ export const tsConfig = (params: Partial<TSConfigParams> = {}) => {
     }),
     name: "@virtual-live-lab/eslint-config/typescript",
     plugins: {
-      "@stylistic/ts": stylisticTs,
+      "@stylistic": stylistic,
     },
     rules: {
-      "@stylistic/ts/no-extra-semi": "error",
+      "@stylistic/no-extra-semi": "error",
       "@typescript-eslint/adjacent-overload-signatures": "off",
       // #175
       "@typescript-eslint/array-type": [

--- a/packages/eslint-config/test/__snapshots__/snapshot.test.ts.snap
+++ b/packages/eslint-config/test/__snapshots__/snapshot.test.ts.snap
@@ -1166,7 +1166,6 @@ exports[`Test ESLint config with snapshot > astro preset > matches snapshot 1`] 
     "@",
     "perfectionist:eslint-plugin-perfectionist@4.15.0",
     "@typescript-eslint:@typescript-eslint/eslint-plugin@8.35.0",
-    "@stylistic/ts",
     "astro:eslint-plugin-astro@1.3.1",
     "jsx-a11y:eslint-plugin-jsx-a11y@6.10.2",
   ],
@@ -1677,7 +1676,7 @@ exports[`Test ESLint config with snapshot > astro preset > matches snapshot 1`] 
       0,
     ],
     "@stylistic/ts/no-extra-semi": [
-      2,
+      0,
     ],
     "@stylistic/ts/object-curly-spacing": [
       0,
@@ -5820,7 +5819,6 @@ exports[`Test ESLint config with snapshot > react preset > matches snapshot 1`] 
     "@",
     "perfectionist:eslint-plugin-perfectionist@4.15.0",
     "@typescript-eslint:@typescript-eslint/eslint-plugin@8.35.0",
-    "@stylistic/ts",
     "react",
     "react-hooks:eslint-plugin-react-hooks",
     "react-refresh",
@@ -6332,7 +6330,7 @@ exports[`Test ESLint config with snapshot > react preset > matches snapshot 1`] 
       0,
     ],
     "@stylistic/ts/no-extra-semi": [
-      2,
+      0,
     ],
     "@stylistic/ts/object-curly-spacing": [
       0,
@@ -7559,7 +7557,6 @@ exports[`Test ESLint config with snapshot > ts preset > matches snapshot 1`] = `
     "@",
     "perfectionist:eslint-plugin-perfectionist@4.15.0",
     "@typescript-eslint:@typescript-eslint/eslint-plugin@8.35.0",
-    "@stylistic/ts",
   ],
   "processor": undefined,
   "rules": {
@@ -8068,7 +8065,7 @@ exports[`Test ESLint config with snapshot > ts preset > matches snapshot 1`] = `
       0,
     ],
     "@stylistic/ts/no-extra-semi": [
-      2,
+      0,
     ],
     "@stylistic/ts/object-curly-spacing": [
       0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,9 @@ importers:
       '@eslint/js':
         specifier: 9.29.0
         version: 9.29.0
-      '@stylistic/eslint-plugin-ts':
-        specifier: 4.4.1
-        version: 4.4.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
+      '@stylistic/eslint-plugin':
+        specifier: 5.2.0
+        version: 5.2.0(eslint@9.28.0(jiti@2.4.2))
       '@typescript-eslint/utils':
         specifier: 8.35.0
         version: 8.35.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
@@ -951,8 +951,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@stylistic/eslint-plugin-ts@4.4.1':
-    resolution: {integrity: sha512-2r6cLcmdF6til66lx8esBYvBvsn7xCmLT50gw/n1rGGlTq/OxeNjBIh4c3VEaDGMa/5TybrZTia6sQUHdIWx1w==}
+  '@stylistic/eslint-plugin@5.2.0':
+    resolution: {integrity: sha512-RCEdbREv9EBiToUBQTlRhVYKG093I6ZnnQ990j08eJ6uRZh71DXkOnoxtTLfDQ6utVCVQzrhZFHZP0zfrfOIjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=9.0.0'
@@ -1036,6 +1036,10 @@ packages:
 
   '@typescript-eslint/types@8.35.0':
     resolution: {integrity: sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.37.0':
+    resolution: {integrity: sha512-ax0nv7PUF9NOVPs+lmQ7yIE7IQmAf8LGcXbMvHX5Gm+YJUYNAl340XkGnrimxZ0elXyoQJuN5sbg6C4evKA4SQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.35.0':
@@ -1690,6 +1694,10 @@ packages:
 
   espree@10.3.0:
     resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   esprima@4.0.1:
@@ -2506,6 +2514,10 @@ packages:
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -4064,15 +4076,15 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.34.9':
     optional: true
 
-  '@stylistic/eslint-plugin-ts@4.4.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)':
+  '@stylistic/eslint-plugin@5.2.0(eslint@9.28.0(jiti@2.4.2))':
     dependencies:
-      '@typescript-eslint/utils': 8.35.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
+      '@typescript-eslint/types': 8.37.0
       eslint: 9.28.0(jiti@2.4.2)
-      eslint-visitor-keys: 4.2.0
-      espree: 10.3.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      estraverse: 5.3.0
+      picomatch: 4.0.3
 
   '@stylistic/stylelint-plugin@3.1.0(stylelint@16.20.0(typescript@5.8.3))':
     dependencies:
@@ -4175,6 +4187,8 @@ snapshots:
 
   '@typescript-eslint/types@8.35.0': {}
 
+  '@typescript-eslint/types@8.37.0': {}
+
   '@typescript-eslint/typescript-estree@8.35.0(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.35.0(typescript@5.8.3)
@@ -4257,6 +4271,10 @@ snapshots:
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
       acorn: 8.14.0
+
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
 
   acorn@8.14.0: {}
 
@@ -5062,6 +5080,12 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.14.0)
       eslint-visitor-keys: 4.2.0
 
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
+
   esprima@4.0.1: {}
 
   esquery@1.5.0:
@@ -5851,6 +5875,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picomatch@4.0.3: {}
 
   pify@2.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       '@eslint/js':
         specifier: 9.29.0
         version: 9.29.0
-      '@stylistic/eslint-plugin':
-        specifier: 5.2.0
-        version: 5.2.0(eslint@9.28.0(jiti@2.4.2))
       '@typescript-eslint/utils':
         specifier: 8.35.0
         version: 8.35.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
@@ -951,12 +948,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@stylistic/eslint-plugin@5.2.0':
-    resolution: {integrity: sha512-RCEdbREv9EBiToUBQTlRhVYKG093I6ZnnQ990j08eJ6uRZh71DXkOnoxtTLfDQ6utVCVQzrhZFHZP0zfrfOIjA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: '>=9.0.0'
-
   '@stylistic/stylelint-plugin@3.1.0':
     resolution: {integrity: sha512-NU2XR6i1x163KdyDj3zqblA13890fBzHNZYqZ13aor/sB3Yq8kU/0NKCudv5pfl9Kb/UAteo/D7vKMHtaror/A==}
     engines: {node: ^18.12 || >=20.9}
@@ -1036,10 +1027,6 @@ packages:
 
   '@typescript-eslint/types@8.35.0':
     resolution: {integrity: sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/types@8.37.0':
-    resolution: {integrity: sha512-ax0nv7PUF9NOVPs+lmQ7yIE7IQmAf8LGcXbMvHX5Gm+YJUYNAl340XkGnrimxZ0elXyoQJuN5sbg6C4evKA4SQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.35.0':
@@ -1694,10 +1681,6 @@ packages:
 
   espree@10.3.0:
     resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  espree@10.4.0:
-    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   esprima@4.0.1:
@@ -2514,10 +2497,6 @@ packages:
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -4076,16 +4055,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.34.9':
     optional: true
 
-  '@stylistic/eslint-plugin@5.2.0(eslint@9.28.0(jiti@2.4.2))':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
-      '@typescript-eslint/types': 8.37.0
-      eslint: 9.28.0(jiti@2.4.2)
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      estraverse: 5.3.0
-      picomatch: 4.0.3
-
   '@stylistic/stylelint-plugin@3.1.0(stylelint@16.20.0(typescript@5.8.3))':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
@@ -4187,8 +4156,6 @@ snapshots:
 
   '@typescript-eslint/types@8.35.0': {}
 
-  '@typescript-eslint/types@8.37.0': {}
-
   '@typescript-eslint/typescript-estree@8.35.0(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.35.0(typescript@5.8.3)
@@ -4271,10 +4238,6 @@ snapshots:
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
       acorn: 8.14.0
-
-  acorn-jsx@5.3.2(acorn@8.15.0):
-    dependencies:
-      acorn: 8.15.0
 
   acorn@8.14.0: {}
 
@@ -5080,12 +5043,6 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.14.0)
       eslint-visitor-keys: 4.2.0
 
-  espree@10.4.0:
-    dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
-      eslint-visitor-keys: 4.2.1
-
   esprima@4.0.1: {}
 
   esquery@1.5.0:
@@ -5875,8 +5832,6 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
-
-  picomatch@4.0.3: {}
 
   pify@2.3.0: {}
 


### PR DESCRIPTION
This plugin was disabled by eslint-config-prettier, so no need to use 