### PR TITLE
Revert "ci: include job in failure url"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
           # Create a comment body
           cat << EOF > COMMENT.md
           ## 🚨 Snapshot test failed
-          See the details: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ github.job }})
+          See the details: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           ### Errors
           EOF


### PR DESCRIPTION
Reverts VirtualLiveLab/js-config#513
`github.job` is not job id but job identifier ( e.g. test )