### PR TITLE
fix(security): update eslint-config-prettier to latest to avoid supply chain attack

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -44,7 +44,7 @@
     "astrojs-compiler-sync": "1.1.1",
     "defu": "6.1.4",
     "eslint-config-flat-gitignore": "2.1.0",
-    "eslint-config-prettier": "10.1.5",
+    "eslint-config-prettier": "10.1.8",
     "eslint-plugin-astro": "1.3.1",
     "eslint-plugin-jsx-a11y": "6.10.2",
     "eslint-plugin-perfectionist": "4.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: 2.1.0
         version: 2.1.0(eslint@9.28.0(jiti@2.4.2))
       eslint-config-prettier:
-        specifier: 10.1.5
-        version: 10.1.5(eslint@9.28.0(jiti@2.4.2))
+        specifier: 10.1.8
+        version: 10.1.8(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-astro:
         specifier: 1.3.1
         version: 1.3.1(eslint@9.28.0(jiti@2.4.2))
@@ -1610,8 +1610,8 @@ packages:
     peerDependencies:
       eslint: ^9.5.0
 
-  eslint-config-prettier@10.1.5:
-    resolution: {integrity: sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==}
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -4901,7 +4901,7 @@ snapshots:
       '@eslint/compat': 1.3.1(eslint@9.28.0(jiti@2.4.2))
       eslint: 9.28.0(jiti@2.4.2)
 
-  eslint-config-prettier@10.1.5(eslint@9.28.0(jiti@2.4.2)):
+  eslint-config-prettier@10.1.8(eslint@9.28.0(jiti@2.4.2)):
     dependencies:
       eslint: 9.28.0(jiti@2.4.2)
 


### PR DESCRIPTION
addressing supply chain attack
https://www.stepsecurity.io/blog/supply-chain-security-alert-eslint-config-prettier-package-shows-signs-of-compromise