### PR TITLE
ci: use OIDC trusted publishing

### DIFF
--- a/.changeset/orange-actors-tie.md
+++ b/.changeset/orange-actors-tie.md
@@ -1,0 +1,8 @@
+---
+"@virtual-live-lab/eslint-config": patch
+"@virtual-live-lab/prettier-config": patch
+"@virtual-live-lab/stylelint-config": patch
+"@virtual-live-lab/tsconfig": patch
+---
+
+ci: use OIDC trusted publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,10 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: ./.github/common/setup-node-pnpm
 
+      - name: Setup latest npm to use trusted publish
+        run: |
+          npm install -g npm@latest
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
@@ -62,7 +66,6 @@ jobs:
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Label PR if not published
         if: steps.changesets.outputs.published != 'true' && steps.changesets.outputs.hasChangesets == 'true'


### PR DESCRIPTION
- お久しぶりです. 部員ではなくこの設定の 1 ユーザーとしての PR です
- おそらく npm token の期限切れが原因で各種 package が publish できなくなっていそうです
  - ref: https://github.com/VirtualLiveLab/js-config/actions/runs/23683236409/job/68998541930
- 2026 年現在の情勢的に固定の npm token を使うことは非推奨と見られるため OIDC trusted publishing に移行して token ごと消すのが良さそうです
  - https://docs.npmjs.com/trusted-publishers
 

## この PR をマージする前にお願いしたいこと
@kohsuke256 
- https://www.npmjs.com/~vll39
  - js-config repo 内のの各種 package について, [docs](https://docs.npmjs.com/trusted-publishers#step-1-add-a-trusted-publisher-on-npmjscom) に従って以下の値で trusted publishing の設定をお願いします
  - `Organization or user`: `VirtualLiveLab`
  - `Repository`: `js-config`
  - `Workflow filename`: `release.yml`
 
## この PR をマージしたあとにお願いしたいこと

- [x] 最新の changest の `Version Packages` PR をマージして新しいバージョンが npm で publish できることの確認
- [ ] GitHub Actions の設定から `NPM_TOKEN` secret を削除してほしいです
  - ついでに 1Password からも